### PR TITLE
Add configurable VAT settings and summary

### DIFF
--- a/MyVateTool/Pages/Invoices.razor
+++ b/MyVateTool/Pages/Invoices.razor
@@ -1,10 +1,27 @@
 @page "/invoices"
 @implements IDisposable
 @inject IJSRuntime JS
+@inject InvoiceService InvoiceService
+@inject UserSettingsService SettingsService
+@using MyVateTool.Services
+@using System.Globalization
+@using System.Linq
+@using System.Threading.Tasks
 
 <h3>📄 Invoices</h3>
 
 <button class="btn btn-primary" @onclick="LoadInvoices">🔄 Load Invoices</button>
+
+@if (HasSummary)
+{
+    <div class="alert alert-info mt-3">
+        <h5 class="alert-heading">VAT summary</h5>
+        <p class="mb-1"><strong>VAT rate:</strong> @VatRateDisplay</p>
+        <p class="mb-1"><strong>Total sales:</strong> @FormatCurrency(totalSales)</p>
+        <p class="mb-1"><strong>Total purchases:</strong> @FormatCurrency(totalPurchases)</p>
+        <p class="mb-0"><strong>Estimated VAT due:</strong> @FormatCurrency(estimatedTax)</p>
+    </div>
+}
 
 @if (invoices == null)
 {
@@ -42,23 +59,50 @@ else
 }
 
 @code {
-    private List<Dictionary<string, string>> invoices;
+    private List<Dictionary<string, string>>? invoices;
+    private List<Invoice> parsedInvoices = new();
+    private UserSettings? settings;
+    private decimal totalSales;
+    private decimal totalPurchases;
+    private decimal estimatedTax;
 
-    private DotNetObjectReference<Invoices> objRef;
+    private DotNetObjectReference<Invoices>? objRef;
+
+    protected override async Task OnInitializedAsync()
+    {
+        settings = await SettingsService.GetSettingsAsync();
+    }
 
     private async Task LoadInvoices()
     {
+        objRef?.Dispose();
         objRef = DotNetObjectReference.Create(this);
         await JS.InvokeVoidAsync("vatHelper.requestInvoices", objRef);
     }
 
     [JSInvokable("ReceiveInvoices")]
-    public Task ReceiveInvoices(List<Dictionary<string, object>> data)
+    public async Task ReceiveInvoices(List<Dictionary<string, object>> data)
     {
-        // Normalize values to strings
-        invoices = data.Select(d => d.ToDictionary(kv => kv.Key, kv => kv.Value?.ToString() ?? "")).ToList();
+        parsedInvoices = InvoiceService.ConvertToInvoices(data).ToList();
+        settings = await SettingsService.GetSettingsAsync();
+
+        totalSales = parsedInvoices
+            .Where(i => i.Type.Equals("Sales", StringComparison.OrdinalIgnoreCase))
+            .Sum(i => i.Amount);
+
+        totalPurchases = parsedInvoices
+            .Where(i => i.Type.Equals("Purchase", StringComparison.OrdinalIgnoreCase))
+            .Sum(i => i.Amount);
+
+        var vatRate = settings?.VatRate ?? 0m;
+        estimatedTax = parsedInvoices.Sum(i => i.Amount * vatRate);
+
+        // Normalize values to strings for the table view
+        invoices = data
+            .Select(d => d.ToDictionary(kv => kv.Key, kv => kv.Value?.ToString() ?? string.Empty))
+            .ToList();
+
         StateHasChanged();
-        return Task.CompletedTask;
     }
 
     public void Dispose()
@@ -66,5 +110,20 @@ else
         objRef?.Dispose();
     }
 
+    private bool HasSummary => settings != null && invoices != null && invoices.Count > 0;
 
+    private string VatRateDisplay => settings == null
+        ? "Not configured"
+        : settings.VatRate.ToString("P2", CultureInfo.CurrentCulture);
+
+    private string FormatCurrency(decimal value)
+    {
+        var symbol = settings?.CurrencySymbol;
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            symbol = "£";
+        }
+
+        return string.Format(CultureInfo.CurrentCulture, "{0}{1:N2}", symbol, value);
+    }
 }

--- a/MyVateTool/Pages/Options.razor
+++ b/MyVateTool/Pages/Options.razor
@@ -1,4 +1,134 @@
-﻿@page "/options.html"
+@page "/options.html"
+@implements IDisposable
+@inject UserSettingsService SettingsService
+@using System.ComponentModel.DataAnnotations
+@using System.Threading
+@using System.Threading.Tasks
+@using MyVateTool.Services
 
+<h1>Extension options</h1>
 
-<h1>My options page</h1>
+@if (model == null)
+{
+    <p>Loading your preferences…</p>
+}
+else
+{
+    <EditForm Model="model" OnValidSubmit="SaveAsync">
+        <DataAnnotationsValidator />
+        <ValidationSummary />
+
+        <div class="mb-3">
+            <label class="form-label" for="vatRate">VAT rate (%)</label>
+            <InputNumber id="vatRate" class="form-control" step="0.01" @bind-Value="model.VatRatePercent" />
+            <div class="form-text">Used when calculating your VAT return estimates.</div>
+        </div>
+
+        <div class="mb-3">
+            <label class="form-label" for="currencySymbol">Currency symbol</label>
+            <InputText id="currencySymbol" class="form-control" maxlength="5" @bind-Value="model.CurrencySymbol" />
+            <div class="form-text">Displayed alongside totals and summaries.</div>
+        </div>
+
+        <div class="form-check mb-3">
+            <InputCheckbox id="autoDownload" class="form-check-input" @bind-Value="model.AutoDownloadReports" />
+            <label class="form-check-label" for="autoDownload">
+                Automatically download a VAT summary after I upload invoices
+            </label>
+        </div>
+
+        <button class="btn btn-primary" type="submit" disabled="@isSaving">
+            @(isSaving ? "Saving…" : "Save changes")
+        </button>
+
+        @if (!string.IsNullOrEmpty(statusMessage))
+        {
+            <div class="alert alert-success mt-3" role="status">@statusMessage</div>
+        }
+    </EditForm>
+}
+
+@code {
+    private SettingsModel? model;
+    private bool isSaving;
+    private string? statusMessage;
+    private CancellationTokenSource? statusMessageCts;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var settings = await SettingsService.GetSettingsAsync();
+        model = SettingsModel.From(settings);
+    }
+
+    private async Task SaveAsync()
+    {
+        if (model == null)
+        {
+            return;
+        }
+
+        isSaving = true;
+        statusMessage = null;
+
+        var settings = model.ToSettings();
+        await SettingsService.SaveSettingsAsync(settings);
+
+        isSaving = false;
+        statusMessage = "Settings saved.";
+
+        StateHasChanged();
+
+        statusMessageCts?.Cancel();
+        statusMessageCts = new CancellationTokenSource();
+        _ = ClearStatusMessageAfterDelayAsync(statusMessageCts.Token);
+    }
+
+    private async Task ClearStatusMessageAfterDelayAsync(CancellationToken token)
+    {
+        try
+        {
+            await Task.Delay(TimeSpan.FromSeconds(4), token);
+        }
+        catch (TaskCanceledException)
+        {
+            return;
+        }
+
+        if (!token.IsCancellationRequested)
+        {
+            statusMessage = null;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    public void Dispose()
+    {
+        statusMessageCts?.Cancel();
+    }
+
+    private class SettingsModel
+    {
+        [Range(0, 100, ErrorMessage = "VAT rate must be between 0 and 100%.")]
+        public decimal VatRatePercent { get; set; }
+
+        [Required(ErrorMessage = "Currency symbol is required.")]
+        [StringLength(5, ErrorMessage = "Currency symbol must be 5 characters or fewer.")]
+        public string CurrencySymbol { get; set; } = "£";
+
+        public bool AutoDownloadReports { get; set; }
+
+        public static SettingsModel From(UserSettings settings) => new()
+        {
+            VatRatePercent = Math.Round(settings.VatRate * 100m, 2, MidpointRounding.AwayFromZero),
+            CurrencySymbol = settings.CurrencySymbol,
+            AutoDownloadReports = settings.AutoDownloadReports
+        };
+
+        public UserSettings ToSettings() => new()
+        {
+            VatRate = VatRatePercent / 100m,
+            CurrencySymbol = CurrencySymbol.Trim(),
+            AutoDownloadReports = AutoDownloadReports
+        };
+    }
+}

--- a/MyVateTool/Program.cs
+++ b/MyVateTool/Program.cs
@@ -30,7 +30,8 @@ builder.Services.AddMudServices();
 
 builder.Services.AddScoped<ExcelJsInterop>();
 builder.Services.AddSyncfusionBlazor();
-builder.Services.AddScoped<InvoiceService>();    
+builder.Services.AddScoped<UserSettingsService>();
+builder.Services.AddScoped<InvoiceService>();
 
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });

--- a/MyVateTool/services/InvoiceService.cs
+++ b/MyVateTool/services/InvoiceService.cs
@@ -6,10 +6,12 @@ namespace MyVateTool.Services
     public class InvoiceService
     {
         private readonly ILocalStorageService _localStorage;
+        private readonly UserSettingsService _settingsService;
 
-        public InvoiceService(ILocalStorageService localStorage)
+        public InvoiceService(ILocalStorageService localStorage, UserSettingsService settingsService)
         {
             _localStorage = localStorage;
+            _settingsService = settingsService;
         }
 
         public async Task<List<Invoice>> GetSalesInvoicesAsync()
@@ -27,9 +29,12 @@ namespace MyVateTool.Services
         public async Task<decimal> CalculateTaxReturnAsync()
         {
             var data = await LoadInvoicesAsync();
-            // مثال: ضريبة 14% من الإجمالي
-            return data.Sum(i => i.Amount * 0.14m);
+            var settings = await _settingsService.GetSettingsAsync();
+            return data.Sum(i => i.Amount * settings.VatRate);
         }
+
+        public IEnumerable<Invoice> ConvertToInvoices(IEnumerable<Dictionary<string, object>> raw)
+            => raw.Select(MapToInvoice);
 
         private async Task<List<Invoice>> LoadInvoicesAsync()
         {

--- a/MyVateTool/services/UserSettingsService.cs
+++ b/MyVateTool/services/UserSettingsService.cs
@@ -1,0 +1,75 @@
+using Blazored.LocalStorage;
+
+namespace MyVateTool.Services
+{
+    public class UserSettingsService
+    {
+        private const string StorageKey = "userSettings";
+        private readonly ILocalStorageService _localStorage;
+
+        public UserSettingsService(ILocalStorageService localStorage)
+        {
+            _localStorage = localStorage;
+        }
+
+        public async Task<UserSettings> GetSettingsAsync()
+        {
+            var settings = await _localStorage.GetItemAsync<UserSettings>(StorageKey);
+            if (settings == null)
+            {
+                settings = UserSettings.CreateDefault();
+                await SaveSettingsAsync(settings);
+                return settings;
+            }
+
+            settings.Normalize();
+            return settings;
+        }
+
+        public async Task SaveSettingsAsync(UserSettings settings)
+        {
+            settings.Normalize();
+            await _localStorage.SetItemAsync(StorageKey, settings);
+        }
+    }
+
+    public class UserSettings
+    {
+        private decimal _vatRate = 0.14m;
+
+        public decimal VatRate
+        {
+            get => _vatRate;
+            set => _vatRate = Clamp(value, 0m, 1m);
+        }
+
+        public string CurrencySymbol { get; set; } = "£";
+
+        public bool AutoDownloadReports { get; set; } = true;
+
+        public static UserSettings CreateDefault() => new();
+
+        internal void Normalize()
+        {
+            VatRate = Clamp(VatRate, 0m, 1m);
+            CurrencySymbol = string.IsNullOrWhiteSpace(CurrencySymbol)
+                ? "£"
+                : CurrencySymbol.Trim();
+        }
+
+        private static decimal Clamp(decimal value, decimal min, decimal max)
+        {
+            if (value < min)
+            {
+                return min;
+            }
+
+            if (value > max)
+            {
+                return max;
+            }
+
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a user settings service to persist VAT configuration in local storage
- build out the options page with a form to edit VAT rate, currency symbol, and report preference
- surface the saved settings by showing a VAT summary on the invoices page and using the configurable rate in tax calculations

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e41bde27848331a4281564d77302f9